### PR TITLE
[ruby 3 upgrades] - migrate to push to github

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,14 +38,14 @@ group :test do
   gem 'simplecov', require: false
 end
 
-package_cloud_token = '40a5c0a37bf51a44a56c18adcf1d28e6ddea73dcfc257d79'
-package_cloud_url = "https://#{package_cloud_token}:@packagecloud.io/tastyworks/gems"
+github_url = 'https://rubygems.pkg.github.com/tastyworks/'
+
 group :test, :development do
   unless ENV['MODEL_PARSER'] == 'grape-swagger-entity'
     gem 'grape-swagger-entity', git: 'https://github.com/ruby-grape/grape-swagger-entity'
   end
 
-  source package_cloud_url do
+  source github_url do
     gem 'tastyworks-development_dependencies', '~> 2.24', '>= 2.24.1'
   end
 end

--- a/grape-swagger.gemspec
+++ b/grape-swagger.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
 
   s.metadata['rubygems_mfa_required'] = 'true'
+  s.metadata['allowed_push_host'] = 'https://rubygems.pkg.github.com/tastyworks'
+  s.metadata['github_repo'] = 'ssh://github.com/tastyworks/common-communications-client-ruby'
 
   s.required_ruby_version = '>= 2.5'
   s.add_runtime_dependency 'grape', '~> 1.3'

--- a/grape-swagger.gemspec
+++ b/grape-swagger.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.metadata['rubygems_mfa_required'] = 'true'
   s.metadata['allowed_push_host'] = 'https://rubygems.pkg.github.com/tastyworks'
-  s.metadata['github_repo'] = 'ssh://github.com/tastyworks/common-communications-client-ruby'
+  s.metadata['github_repo'] = 'ssh://github.com/tastyworks/grape-swagger'
 
   s.required_ruby_version = '>= 2.5'
   s.add_runtime_dependency 'grape', '~> 1.3'


### PR DESCRIPTION
## Type of change
- [ ] Feature
- [x] Tech improvement / refactor
- [ ] Bugfix

## Reason for the change
Adding this package to github, so that other gems, like https://github.com/tastyworks/tastyworks-documentation-ruby/blob/master/Gemfile can also migrate to github

This will also serve to bind the [package](https://github.com/orgs/tastyworks/packages/rubygems/package/tastyworks-grape_swagger) to our repo, then we can give the access to deployer

This could also be fixed by adding 
```
package_cloud_token = '40a5c0a37bf51a44a56c18adcf1d28e6ddea73dcfc257d79'
package_cloud_url = "https://#{package_cloud_token}:@packagecloud.io/tastyworks/gems"

  source package_cloud_url do
    gem 'tastyworks-grape_swagger'
  end
```
But it's not our aim to have two different sources

## Dependencies
https://github.com/tastyworks/regional-behavior-api/pull/1

## Gem version bump
Was lib code modified? What kind of change is this? i.e. [Major, Minor or Patch](https://semver.org/)

- [ ] Major: Incompatible changes for clients of the gem (i.e. breaking changes in public interface)
- [ ] Minor: Backwards compatible new functionality
- [x] Patch: Backwards compatible bug fixes
- [ ] None: No lib code was changed
