### PR TITLE
Cast JSON parameter type to object

### DIFF
--- a/lib/grape-swagger/doc_methods/data_type.rb
+++ b/lib/grape-swagger/doc_methods/data_type.rb
@@ -10,9 +10,9 @@ module GrapeSwagger
           raw_data_type = parse_multi_type(raw_data_type)
 
           case raw_data_type.to_s
-          when 'Boolean', 'Date', 'Integer', 'String', 'Float', 'JSON', 'Array'
+          when 'Boolean', 'Date', 'Integer', 'String', 'Float', 'Array'
             raw_data_type.to_s.downcase
-          when 'Hash'
+          when 'Hash', 'JSON'
             'object'
           when 'Rack::Multipart::UploadedFile', 'File'
             'file'


### PR DESCRIPTION
The JSON/json type is not valid, per the [Swagger spec](https://swagger.io/docs/specification/2-0/describing-request-body/)

This will convert JSON into object, which is valid.