### PR TITLE
File types must be string with byte format

### DIFF
--- a/lib/grape-swagger/doc_methods/data_type.rb
+++ b/lib/grape-swagger/doc_methods/data_type.rb
@@ -15,7 +15,7 @@ module GrapeSwagger
           when 'Hash', 'JSON'
             'object'
           when 'Rack::Multipart::UploadedFile', 'File'
-            'file'
+            'byte'
           when 'Grape::API::Boolean'
             'boolean'
           when 'BigDecimal'


### PR DESCRIPTION
https://swagger.io/docs/specification/data-models/data-types/#file

```
"definitions": {
    "postAccountsAccountNumberDocumentsJumbo": {
      "type": "object",
      "properties": {
        "document": {
          "type": "string",
          "format": "byte",
          "description": "Document file"
        }
...
```