### PR TITLE
COM-5341: Show the correct path item for overloaded endpoints

### DIFF
--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -120,7 +120,9 @@ module Grape
     end
 
     def sort_paths
-      @paths.transform_values! { |objects| objects.sort_by { |verb, _object| VERBS_ORDER.index(verb) }.to_h }
+      @paths.transform_values! do |objects|
+        objects.sort_by { |verb, _object| VERBS_ORDER.index(verb) || VERBS_ORDER.size }.to_h
+      end
       @paths = @paths.sort_by { |(path, _objects)| path }.to_h
     end
 

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -6,6 +6,8 @@ require 'grape-swagger/endpoint/params_parser'
 
 module Grape
   class Endpoint # rubocop:disable Metrics/ClassLength
+    VERBS_ORDER = %i[get post put patch delete options head].freeze
+
     def content_types_for(target_class)
       content_types = (target_class.content_types || {}).values
 
@@ -84,6 +86,8 @@ module Grape
         path_item(routes, options)
       end
 
+      sort_paths
+
       [@paths, @definitions]
     end
 
@@ -103,6 +107,8 @@ module Grape
 
         verb, method_object = method_object(route, options, path)
 
+        next if @paths.dig(path.to_s, verb)
+
         if @paths.key?(path.to_s)
           @paths[path.to_s][verb] = method_object
         else
@@ -111,6 +117,11 @@ module Grape
 
         GrapeSwagger::DocMethods::Extensions.add(@paths[path.to_s], @definitions, route)
       end
+    end
+
+    def sort_paths
+      @paths.transform_values! { |objects| objects.sort_by { |verb, _object| VERBS_ORDER.index(verb) }.to_h }
+      @paths = @paths.sort_by { |(path, _objects)| path }.to_h
     end
 
     def method_object(route, options, path)
@@ -387,7 +398,7 @@ module Grape
       return param unless stackable_values
       return params unless stackable_values.is_a? Grape::Util::StackableValues
 
-      stackable_values&.new_values&.dig(:namespace)&.each do |namespace|
+      stackable_values.new_values&.dig(:namespace)&.each do |namespace|
         space = namespace.space.to_s.gsub(':', '')
         params[space] = namespace.options || {}
       end

--- a/spec/support/model_parsers/entity_parser.rb
+++ b/spec/support/model_parsers/entity_parser.rb
@@ -199,10 +199,10 @@ RSpec.shared_context 'entity swagger example' do
       'host' => 'example.org',
       'basePath' => '/api',
       'tags' => [
-        { 'name' => 'other_thing', 'description' => 'Operations about other_things' },
+        { 'name' => 'dummy', 'description' => 'Operations about dummies' },
         { 'name' => 'thing', 'description' => 'Operations about things' },
         { 'name' => 'thing2', 'description' => 'Operations about thing2s' },
-        { 'name' => 'dummy', 'description' => 'Operations about dummies' }
+        { 'name' => 'other_thing', 'description' => 'Operations about other_things' }
       ],
       'paths' => {
         '/v3/other_thing/{elements}' => {

--- a/spec/support/model_parsers/mock_parser.rb
+++ b/spec/support/model_parsers/mock_parser.rb
@@ -207,10 +207,10 @@ RSpec.shared_context 'mock swagger example' do
       'host' => 'example.org',
       'basePath' => '/api',
       'tags' => [
-        { 'name' => 'other_thing', 'description' => 'Operations about other_things' },
+        { 'name' => 'dummy', 'description' => 'Operations about dummies' },
         { 'name' => 'thing', 'description' => 'Operations about things' },
         { 'name' => 'thing2', 'description' => 'Operations about thing2s' },
-        { 'name' => 'dummy', 'description' => 'Operations about dummies' }
+        { 'name' => 'other_thing', 'description' => 'Operations about other_things' }
       ],
       'paths' => {
         '/v3/other_thing/{elements}' => {

--- a/spec/support/model_parsers/representable_parser.rb
+++ b/spec/support/model_parsers/representable_parser.rb
@@ -271,10 +271,10 @@ RSpec.shared_context 'representable swagger example' do
       'host' => 'example.org',
       'basePath' => '/api',
       'tags' => [
-        { 'name' => 'other_thing', 'description' => 'Operations about other_things' },
+        { 'name' => 'dummy', 'description' => 'Operations about dummies' },
         { 'name' => 'thing', 'description' => 'Operations about things' },
         { 'name' => 'thing2', 'description' => 'Operations about thing2s' },
-        { 'name' => 'dummy', 'description' => 'Operations about dummies' }
+        { 'name' => 'other_thing', 'description' => 'Operations about other_things' }
       ],
       'paths' => {
         '/v3/other_thing/{elements}' => {

--- a/spec/support/overridden_endpoint.rb
+++ b/spec/support/overridden_endpoint.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'overridden endpoint' do
+  context 'api documentation' do
+    subject do
+      get '/swagger_doc'
+      JSON.parse(last_response.body)['paths']['/']['get']
+    end
+
+    it 'shows documentation from new endpoint' do
+      expect(subject['parameters'][0]['description']).to eql('new param')
+      expect(subject['parameters'][0]['type']).to eql('string')
+      expect(subject['responses']['200']['description']).to eql('new message')
+    end
+  end
+
+  context 'api response' do
+    subject { get '/' }
+
+    it 'returns new response' do
+      expect(subject.body).to eql('new')
+    end
+  end
+end

--- a/spec/swagger_v2/hide_api_spec.rb
+++ b/spec/swagger_v2/hide_api_spec.rb
@@ -48,7 +48,7 @@ describe 'a hide mounted api' do
       'swagger' => '2.0',
       'produces' => ['application/xml', 'application/json', 'application/octet-stream', 'text/plain'],
       'host' => 'example.org',
-      'tags' => [{ 'name' => 'simple', 'description' => 'Operations about simples' }, { 'name' => 'lazy', 'description' => 'Operations about lazies' }],
+      'tags' => [{ 'name' => 'lazy', 'description' => 'Operations about lazies' }, { 'name' => 'simple', 'description' => 'Operations about simples' }],
       'paths' => {
         '/simple' => {
           'get' => {

--- a/spec/swagger_v2/namespace_tags_prefix_spec.rb
+++ b/spec/swagger_v2/namespace_tags_prefix_spec.rb
@@ -64,7 +64,7 @@ describe 'namespace tags check while using prefix and version' do
     end
 
     specify do
-      expect(subject['tags']).to eql(
+      expect(subject['tags']).to match_array(
         [
           { 'name' => 'hudson', 'description' => 'Operations about hudsons' },
           { 'name' => 'colorado', 'description' => 'Operations about colorados' },

--- a/spec/swagger_v2/namespace_tags_spec.rb
+++ b/spec/swagger_v2/namespace_tags_spec.rb
@@ -23,7 +23,7 @@ describe 'namespace tags check' do
     end
 
     specify do
-      expect(subject['tags']).to eql(
+      expect(subject['tags']).to match_array(
         [
           { 'name' => 'hudson', 'description' => 'Operations about hudsons' },
           { 'name' => 'colorado', 'description' => 'Operations about colorados' },

--- a/spec/swagger_v2/override_endpoint_spec.rb
+++ b/spec/swagger_v2/override_endpoint_spec.rb
@@ -14,7 +14,9 @@ describe 'mount override api' do
       end
     end
 
-    new_api = Class.new(Grape::API) do
+    Class.new(Grape::API) do
+      mount old_api
+
       desc 'new endpoint', success: { code: 200, message: 'new message' }
       params do
         optional :param, type: String, desc: 'new param'
@@ -22,11 +24,6 @@ describe 'mount override api' do
       get do
         'new'
       end
-    end
-
-    Class.new(Grape::API) do
-      mount new_api
-      mount old_api
 
       add_swagger_documentation format: :json
     end

--- a/spec/swagger_v2/simple_mounted_api_spec.rb
+++ b/spec/swagger_v2/simple_mounted_api_spec.rb
@@ -100,13 +100,13 @@ describe 'a simple mounted api' do
         'produces' => ['application/xml', 'application/json', 'application/octet-stream', 'text/plain'],
         'host' => 'example.org',
         'tags' => [
+          { 'name' => 'custom', 'description' => 'Operations about customs' },
+          { 'name' => 'items', 'description' => 'Operations about items' },
           { 'name' => 'simple', 'description' => 'Operations about simples' },
-          { 'name' => 'simple-test', 'description' => 'Operations about simple-tests' },
           { 'name' => 'simple-head-test', 'description' => 'Operations about simple-head-tests' },
           { 'name' => 'simple-options-test', 'description' => 'Operations about simple-options-tests' },
-          { 'name' => 'simple_with_headers', 'description' => 'Operations about simple_with_headers' },
-          { 'name' => 'items', 'description' => 'Operations about items' },
-          { 'name' => 'custom', 'description' => 'Operations about customs' }
+          { 'name' => 'simple-test', 'description' => 'Operations about simple-tests' },
+          { 'name' => 'simple_with_headers', 'description' => 'Operations about simple_with_headers' }
         ],
         'paths' => {
           '/' => {


### PR DESCRIPTION
This replicates Grape's actual behavior for picking the overloaded endpoint. Might create a PR to the upstream as well.

Also added endpoint sorting for better representation.